### PR TITLE
Adjust mobile overlay styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,3 +51,17 @@ body {
 .email-btn:hover {
     background-color: rgba(0, 0, 0, 0.7);
 }
+
+@media (max-width: 600px) {
+    .overlay h1 {
+        font-size: 2.2rem;
+    }
+
+    .overlay p {
+        font-size: 1.1rem;
+    }
+
+    .email-btn {
+        padding: 8px 16px;
+    }
+}


### PR DESCRIPTION
## Summary
- add responsive CSS rules for overlay elements on small screens

## Testing
- `npx --yes stylelint style.css` (fails: No configuration provided for style.css)
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_688f29e216d88328b67ddf7f21e844bf